### PR TITLE
Implement webrtc client

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,22 +8,59 @@ const app: Application = express();
 app.use(cors());
 
 const PORT = process.env.PORT || 5000;
-const server = app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+const server = app.listen(PORT, () => console.log(`WebRTC Signaling Server running on port ${PORT}`));
 
 const wss = new WebSocketServer({ server });
 
+const rooms: Map<string, Set<WebSocket>> = new Map();
+
 wss.on("connection", (ws: WebSocket) => {
-  console.log("✅ New client connected");
+  console.log("New client connected");
 
-  ws.on("message", (data: string) => {
-    console.log("📩 Received:", data);
+  let currentRoom: string | null = null;
 
-    wss.clients.forEach((client) => {
-      if (client !== ws && client.readyState === WebSocket.OPEN) {
-        client.send(data);
+  ws.on("message", (message: string) => {
+    try {
+      const data = JSON.parse(message);
+
+      if (data.type === "join") {
+        const { roomId } = data;
+        if (!roomId) return;
+
+        if (!rooms.has(roomId)) {
+          rooms.set(roomId, new Set());
+        }
+
+        rooms.get(roomId)?.add(ws);
+        currentRoom = roomId;
+
+        console.log(`Client joined room: ${roomId}`);
+        return;
       }
-    });
+
+      // WebRTC Signaling
+      if (["offer", "answer", "candidate"].includes(data.type) && currentRoom && rooms.has(currentRoom)) {
+        rooms.get(currentRoom)?.forEach((client) => {
+          if (client !== ws && client.readyState === WebSocket.OPEN) {
+            client.send(JSON.stringify(data));
+          }
+        });
+      }
+
+    } catch (err) {
+      console.error("Error processing message:", err);
+    }
   });
 
-  ws.on("close", () => console.log("❌ Client disconnected"));
+  ws.on("close", () => {
+    console.log("Client disconnected");
+
+    if (currentRoom && rooms.has(currentRoom)) {
+      rooms.get(currentRoom)?.delete(ws);
+      if (rooms.get(currentRoom)?.size === 0) {
+        rooms.delete(currentRoom);
+        console.log(`🗑 Room ${currentRoom} deleted (no users left)`);
+      }
+    }
+  });
 });

--- a/frontend/src/webrtc.ts
+++ b/frontend/src/webrtc.ts
@@ -1,0 +1,131 @@
+// Dummy socket for now
+const socket: WebSocket = new WebSocket("ws://localhost:5000");
+
+interface PeerConnections {
+  [key: string]: RTCPeerConnection;
+}
+
+interface DataChannels {
+  [key: string]: RTCDataChannel;
+}
+
+const peerConnections: PeerConnections = {}; // store p2p connections
+const dataChannels: DataChannels = {}; // store channels for drawing data
+
+// handles backend websocket events
+socket.onmessage = async (event: MessageEvent) => {
+  const data = JSON.parse(event.data);
+
+  if (data.type === "offer") {
+    await handleOffer(data.offer, data.senderId);
+  } else if (data.type === "answer") {
+    await handleAnswer(data.answer, data.senderId);
+  } else if (data.type === "candidate") {
+    await handleCandidate(data.candidate, data.senderId);
+  }
+};
+
+// makes p2p connection
+async function createPeerConnection(peerId: string): Promise<RTCPeerConnection> {
+  const peer = new RTCPeerConnection({
+    iceServers: [{ urls: "stun:stun.l.google.com:19302" }], // Free STUN server
+  });
+
+  peer.onicecandidate = (event: RTCPeerConnectionIceEvent) => {
+    if (event.candidate) {
+      socket.send(
+        JSON.stringify({
+          type: "candidate",
+          candidate: event.candidate,
+          senderId: socket.url,
+        })
+      );
+    }
+  };
+
+  // data channel for RECEIVING drawing data
+  peer.ondatachannel = (event: RTCDataChannelEvent) => {
+    const channel = event.channel;
+    dataChannels[peerId] = channel;
+
+    channel.onopen = () => console.log("WebRTC DataChannel open!");
+    channel.onmessage = (event: MessageEvent) => handleDrawingData(event.data);
+  };
+
+  // data channel for SENDING drawing data
+  const dataChannel: RTCDataChannel = peer.createDataChannel("drawing");
+  dataChannels[peerId] = dataChannel;
+
+  dataChannel.onopen = () => console.log("WebRTC DataChannel open!");
+  dataChannel.onmessage = (event: MessageEvent) => handleDrawingData(event.data);
+
+  peerConnections[peerId] = peer;
+  return peer;
+}
+
+// WebRTC offer 
+async function handleOffer(offer: RTCSessionDescriptionInit, senderId: string): Promise<void> {
+  const peer = await createPeerConnection(senderId);
+  await peer.setRemoteDescription(new RTCSessionDescription(offer));
+  const answer = await peer.createAnswer();
+  await peer.setLocalDescription(answer);
+
+  socket.send(
+    JSON.stringify({
+      type: "answer",
+      answer,
+      senderId,
+    })
+  );
+}
+
+// WebRTC answer
+async function handleAnswer(answer: RTCSessionDescriptionInit, senderId: string): Promise<void> {
+  if (peerConnections[senderId]) {
+    await peerConnections[senderId].setRemoteDescription(new RTCSessionDescription(answer));
+  }
+}
+
+// Handle ICE candidate
+async function handleCandidate(candidate: RTCIceCandidateInit, senderId: string): Promise<void> {
+  if (peerConnections[senderId]) {
+    await peerConnections[senderId].addIceCandidate(new RTCIceCandidate(candidate));
+  }
+}
+
+// join room
+function joinRoom(roomId: string): void {
+  socket.send(JSON.stringify({ type: "join", roomId }));
+
+  socket.onopen = async () => {
+    const peer = await createPeerConnection(roomId);
+    const offer = await peer.createOffer();
+    await peer.setLocalDescription(offer);
+
+    socket.send(
+      JSON.stringify({
+        type: "offer",
+        offer,
+        senderId: socket.url,
+      })
+    );
+  };
+}
+
+// sending drawing data
+function sendDrawingData(data: string): void {
+  Object.values(dataChannels).forEach((channel) => {
+    if (channel.readyState === "open") {
+      channel.send(data);
+    }
+  });
+}
+
+// receiving drawing data
+function handleDrawingData(data: string): void {
+  console.log("🖊 Drawing event received:", data);
+  // Integrate with frontend drawing logic here
+}
+
+// export
+export { joinRoom, sendDrawingData };


### PR DESCRIPTION
### WebRTC server setup

Implemented a signaling server that does room management. The frontend client will handle creating a P2P connection with users in the same room (see `/frontend/src/webrtc.ts`). WebRTC does require the server to set up the initial connection. Currently, the server handles `join` messages by creating a WebSocket for each room. Any other message is assumed to be for creating the P2P connection and just forwards it all clients in the same room as the user.

#### Testing
Run `npm run dev` to create the backend server. You can join the server by using `wscat`. You can then create a P2P by sending any message (but preferably, you send something like `socket.send(JSON.stringify({ type: "offer", offer, senderId: socket.id }));`)